### PR TITLE
set interval to 5 min

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ OUTER:
 		select {
 		case <-ctx.Done():
 			break OUTER
-		case <-time.After(600 * time.Second):
+		case <-time.After(300 * time.Second):
 		}
 	}
 }


### PR DESCRIPTION
Reduces the time to wait between iterations from 10 min to 5 min. A higher frequency should result in more reliable statistics for p95 and p99.