### PR TITLE
Add user agent

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,6 +56,7 @@ func (s *client) search(ctx context.Context, queryString string) (*result, *metr
 
 	req.Header.Set("Authorization", "token "+s.token)
 	req.Header.Set("X-Sourcegraph-Should-Trace", "true")
+	req.Header.Set("User-Agent", "SearchBlitz (monitoring)")
 
 	start := time.Now()
 	resp, err := s.client.Do(req)


### PR DESCRIPTION
Adds a useragent so requests from search-blitz can be identified.
Additionally adds a comment with the monitoring tag so we can easily
group monitoring-sourced requests if necessary.