### PR TITLE
Update sourcegraph/alpine base images to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o searchblitz .
 
-FROM sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
+FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
 RUN mkdir data
 
 COPY --from=builder /build/searchblitz /usr/local/bin


### PR DESCRIPTION
This PR updates sourcegraph/alpine base images to latest

[_Created by Sourcegraph batch change `andre/update-alpine-base-images`._](https://k8s.sgdev.org/users/andre/batch-changes/update-alpine-base-images)